### PR TITLE
batch hubRelease for Release and hubCollaborators to Collaborator 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nina-protocol/js-sdk",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "A Javascript SDK for the Nina Protocol",
   "source": "src/index.js",
   "main": "dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nina-protocol/js-sdk",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "A Javascript SDK for the Nina Protocol",
   "source": "src/index.js",
   "main": "dist/index.cjs",

--- a/src/client.js
+++ b/src/client.js
@@ -101,10 +101,6 @@ class NinaClient {
       const publicKey = url.split('/')[2];
       await this.processMulitpleHubAccountData(response.data.hubs)
       await this.processMultipleHubCollaboratorAccountDataWithHubs(response.data.hubs, publicKey);
-      console.log('response: ', response.data)
-      // for await (let hub of response.data.hubs) {
-      //   hub.accountData.collaborator = await this.processAndParseSingleHubCollaboratorAccountDataWithHub(publicKey, hub.publicKey)
-      // }
     } else if (
       url === '/releases' ||
       /accounts\/(.*?)\/published/.test(url) ||

--- a/src/client.js
+++ b/src/client.js
@@ -87,13 +87,7 @@ class NinaClient {
     } else if (/releases\/(.*?)\/hubs/.test(url)) {
       const releasePublicKey = url.split("/")[2];
       await this.processMulitpleHubAccountData(response.data.hubs)
-      for await (let hub of response.data.hubs) {
-        const accountData = await this.processHubReleaseAccountDataWithHub(releasePublicKey, hub.publicKey);
-        hub.accountData = {
-          ...hub.accountData,
-          ...accountData
-        };
-      }
+      await this.processMultipleHubReleasesAccountDataWithHub(response.data.hubs, releasePublicKey);
     } else if (url === '/hubs') {
       await this.processMulitpleHubAccountData(response.data.hubs)
     } else if (/releases\/(.*?)\/revenueShareRecipients/.test(url)) { 
@@ -106,9 +100,11 @@ class NinaClient {
     } else if (/accounts\/(.*?)\/hubs/.test(url)) {
       const publicKey = url.split('/')[2];
       await this.processMulitpleHubAccountData(response.data.hubs)
-      for await (let hub of response.data.hubs) {
-        hub.accountData.collaborator = await this.processAndParseSingleHubCollaboratorAccountDataWithHub(publicKey, hub.publicKey)
-      }
+      await this.processMultipleHubCollaboratorAccountDataWithHubs(response.data.hubs, publicKey);
+      console.log('response: ', response.data)
+      // for await (let hub of response.data.hubs) {
+      //   hub.accountData.collaborator = await this.processAndParseSingleHubCollaboratorAccountDataWithHub(publicKey, hub.publicKey)
+      // }
     } else if (
       url === '/releases' ||
       /accounts\/(.*?)\/published/.test(url) ||
@@ -241,6 +237,31 @@ class NinaClient {
     }
   }
 
+  async processMultipleHubCollaboratorAccountDataWithHubs (data, collaboratorPublicKey) {
+    const publicKeys  = data.map(hub => hub.publicKey);
+    const hubCollaboratorPublicKeys = []
+    for await (let publicKey of publicKeys) {
+      const [hubCollaborator] = await anchor.web3.PublicKey.findProgramAddress(
+        [
+          Buffer.from(anchor.utils.bytes.utf8.encode('nina-hub-collaborator')),
+          (new anchor.web3.PublicKey(publicKey)).toBuffer(),
+          (new anchor.web3.PublicKey(collaboratorPublicKey)).toBuffer(),
+        ],
+        new anchor.web3.PublicKey(this.programId)
+      )
+      hubCollaboratorPublicKeys.push(hubCollaborator.toBase58())
+    }
+
+    const collaborators = await this.fetchAccountDataMultiple(hubCollaboratorPublicKeys, "hubCollaborator");
+    let i = 0
+    for await (let collaborator of collaborators) {
+      const hubCollaboratorPublicKey = hubCollaboratorPublicKeys[i]
+      const parsedCollaborator = this.parseHubCollaboratorAccountData(collaborator, hubCollaboratorPublicKey);
+      data[i].accountData.collaborator = parsedCollaborator;
+      i++;
+    }
+  }
+
   async processAndParseSingleHubCollaboratorAccountDataWithHub (publicKey, hubPublicKey) {
     const [hubCollaborator] = await anchor.web3.PublicKey.findProgramAddress(
       [
@@ -254,6 +275,46 @@ class NinaClient {
     const collaborator = await this.fetchAccountData(hubCollaboratorPublicKey, "hubCollaborator");
     const parsedCollaborator = this.parseHubCollaboratorAccountData(collaborator, hubCollaboratorPublicKey);
     return parsedCollaborator
+  }
+
+  async processMultipleHubReleasesAccountDataWithHub (data, releasePublicKey) {
+    const hubReleasePublicKeys = []
+    const hubContentPublicKeys = []
+    for await (let hub of data) {
+      const [hubReleasePublicKey] = await anchor.web3.PublicKey.findProgramAddress(
+        [
+          Buffer.from(anchor.utils.bytes.utf8.encode(`nina-hub-release`)),
+          new anchor.web3.PublicKey(hub.publicKey).toBuffer(),
+          new anchor.web3.PublicKey(releasePublicKey).toBuffer(),
+        ],
+        this.program.programId
+      )
+      hubReleasePublicKeys.push(hubReleasePublicKey)
+      const [hubContentPublicKey] = await anchor.web3.PublicKey.findProgramAddress(
+        [
+          Buffer.from(anchor.utils.bytes.utf8.encode(`nina-hub-content`)),
+          new anchor.web3.PublicKey(hub.publicKey).toBuffer(),
+          new anchor.web3.PublicKey(releasePublicKey).toBuffer(),
+        ],
+        this.program.programId
+      )
+        
+      hubContentPublicKeys.push(hubContentPublicKey)
+    }
+    const hubReleases = await this.fetchAccountDataMultiple(hubReleasePublicKeys, 'hubRelease');
+    const hubContent = await this.fetchAccountDataMultiple(hubContentPublicKeys, 'hubContent');
+
+    let i = 0;
+    for await (let hub of data) {
+      const parsedHubRelease = this.parseHubReleaseAccountData(hubReleases[i], hubReleasePublicKeys[i]);
+      const parsedHubContent = this.parseHubContentAccountData(hubContent[i], hubContentPublicKeys[i]);
+      hub.accountData = {
+        hub,
+        hubRelease: parsedHubRelease,
+        hubContent: parsedHubContent,
+      };
+      i++;
+    }
   }
 
   async processHubReleaseAccountDataWithHub (releasePublicKey, hubPublicKey) {


### PR DESCRIPTION
i noticed on an account with 40 hubs on initial load there would be 100+ calls to the chain

on a release page with 20 hubs there would be ~60+ calls to the chain

initial load with a release page with a connected wallet would take over 15 secs to complete

both of the calls to get a releases hub and a users hubs were being run inefficiently, so i put them in a batch call to the chain.  we go from 150+ calls to 8

npm package has already been updated to 0.0.15 via npm publish but there was a log so i had to goto 0.016 - we should get ci/cd workflow for this at some point to check for logs, run the build script and publish.  i can also imagine some ways we could have tests for validating output